### PR TITLE
feat(matrix-build-scan-push): add new build-scan-push workflow

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -1,0 +1,172 @@
+name: Build, Scan, and Push
+
+on:
+  workflow_call:
+    inputs:
+      # Image metadata
+      repository:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+
+      # Use a Skaffold build Matrix OR a single image
+      image-name:
+        required: false
+        type: string
+        default: ''
+      working-directory:
+        description: 'Image build context'
+        type: string
+        required: false
+        default: '.' 
+      # This has lower precendance that the image-name.
+      build-matrix:
+        description: '[{image,context}] matrix, like a skaffold.yml file'
+        type: string
+        required: false
+        default: '' 
+      # Build Matrix
+      ## Don't use this if using a matrix
+      dockerfile:
+        description: 'Dockerfile path'
+        type: string
+        required: false
+        default: 'Dockerfile' 
+
+      # Build options
+      publish:
+        required: false
+        type: boolean
+        default: false
+      nofail:
+        required: false
+        type: boolean
+        default: false
+      build-args:
+        required: false
+        type: string
+      publish-args:
+        required: false
+        type: string
+
+      platforms:
+        description: "Platforms to build with buildx"
+        type: string
+        required: false
+        default: "linux/amd64"
+
+      # Container Registry config
+      registry-username:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      registry-password:
+        required: false
+
+jobs:
+  listimages:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.result }}
+    steps:
+    - uses: actions/checkout@master
+    - id: get-matrix
+      uses: mikefarah/yq@master
+      with:
+        cmd: |
+          if test -z '${{ inputs.build-matrix }}'; then
+            echo '[{"image":"${{inputs.image-name}}","context":"${{inputs.working-directory}}"}]';
+          else
+            printf '['
+            cat <<EOF | yq -o=json e . - | tr -d '[[:space:]]'
+          ${{ inputs.build-matrix }}
+          EOF
+            printf ']'
+          fi
+
+  build:
+    name: Build & Push
+    needs: [listimages]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: 
+        include: ${{fromJson(needs.listimages.outputs.matrix)}}
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          load: true
+          #outputs: type=oci,dest=/tmp/image-${{ inputs.image-name }}.tar
+          tags: ${{ inputs.repository }}/${{ matrix.image }}:${{ inputs.tag }}
+          build-args: ${{ inputs.build-args }}
+
+      # Adapted from
+      # https://github.com/actions/starter-workflows/blob/7e07c9f957bcf13ea918eed46110c52e678649c0/code-scanning/trivy.yml#L20-L47
+      - name: Convert nofail to exit code
+        id: exit-code
+        run: |
+          if test "${{ inputs.nofail }}" = "true"; then
+            exit_code=0
+          else
+            exit_code=1
+          fi
+          printf '::set-output name=exit_code::%d\n' $exit_code
+
+      # Scan
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@2a2157eb22c08c9a1fac99263430307b8d1bc7a2
+        with:
+          image-ref: ${{ inputs.repository }}/${{ matrix.image }}:${{ inputs.tag }}
+          #input: /tmp/image-${{ inputs.image-name }}.tar
+          format: 'template'
+          exit-code: ${{ steps.exit-code.outputs.exit_code }}
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: CRITICAL
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          checkout_path: ${{ matrix.context }}
+
+      - name: Login to Container Registry
+        if: ${{ inputs.publish }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.repository }}
+          username: ${{ inputs.repository-username }}
+          password: ${{ inputs.repository-password }}
+
+      - name: Push
+        if: ${{ inputs.publish }}
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ inputs.repository }}/${{ matrix.image }}:${{ inputs.tag }}
+          build-args: ${{ inputs.publish-args }}

--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -158,7 +158,7 @@ jobs:
         with:
           registry: ${{ inputs.repository }}
           username: ${{ inputs.repository-username }}
-          password: ${{ inputs.repository-password }}
+          password: ${{ secrets.repository-password }}
 
       - name: Push
         if: ${{ inputs.publish }}


### PR DESCRIPTION
This PR adds a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) build workflow, which builds, scans, and pushes, uploading the scan results to the code scanning tab.

# TODO

Builds & Scans are well tested, I need to test the publish/push logic more before merging.

# See it in action

This is an example for the [builder-images repo](https://github.com/blairdrummond/builder-images/security/code-scanning). Where we instantiated the re-usable workflow in this PR using the following workflow.

**NOTE: This workflow is unpacking the list of images from the [skaffold.yaml](https://github.com/blairdrummond/builder-images/blob/d6ce5c17805a4a37e83761f153b692215ae6043d/skaffold.yaml#L3-L32) file. You could also write a matrix inline as a string.**

```yaml
name: build
on: 
- push

jobs:
  listimages:
    runs-on: ubuntu-latest
    outputs:
      matrix: ${{ steps.get-matrix.outputs.result }}
    steps:
    - uses: actions/checkout@master
    - id: get-matrix
      uses: mikefarah/yq@v4.25.1
      with:
        # Get the build matrix from the skaffold.yaml file.
        cmd: |
          yq e .build.artifacts skaffold.yaml

  build:
    uses: blairdrummond/github-workflows/.github/workflows/build-scan-push.yaml@main
    needs: [listimages]
    with:
      repository: "ghcr.io/blairdrummond/github-workflows"
      tag: latest
      build-matrix: ${{ needs.listimages.outputs.matrix }}
```

<img width="1682" alt="Screen Shot 2022-05-19 at 3 27 13 PM" src="https://user-images.githubusercontent.com/10801138/169386948-2a8ac4f7-9d05-40f9-9713-0baa6556c2b4.png">

<img width="1302" alt="Screen Shot 2022-05-19 at 3 20 37 PM" src="https://user-images.githubusercontent.com/10801138/169386967-10b8acf0-5edf-41d8-8e13-3ffe958c9cbc.png">

<img width="2343" alt="Screen Shot 2022-05-19 at 3 20 54 PM" src="https://user-images.githubusercontent.com/10801138/169386994-21f79e3e-269e-464a-8eb7-7bdf4da0060e.png">

# Design quirks

## Why push the matrix strategy logic into the workflow itself? Why not just call the re-usable workflow using a matrix?

You might think it'd be nicer to do something like this

```yaml
# This doesn't work
jobs:
  build-scan:
    strategy:
      matrix:
        instances:
        - image: maven
          context: ./maven
        - image: python
          context: ./python
    uses: ./.github/workflows/build-scan-push.yaml
    with:
      image: ${{ matrix.image }}
      context: ${{ matrix.context }}
```

And that would be lovely and more elegant than parsing a yaml matrix. However, [it's not supported](https://stackoverflow.com/a/70173578) :(

## This is handling both a matrix input, or a single image-name. Why not have a separate workflow for the singleton image build to simplify things?

Apparently reusable workflows can't call other reusable workflows

https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations

So you would need to duplicate all the building & scanning logic in both workflows. I am not against that necessarily, but it is a lot of duplicated code.
