### PR TITLE
fix: repository-username and repository-password aren't real inputs

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -157,8 +157,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ inputs.repository }}
-          username: ${{ inputs.repository-username }}
-          password: ${{ secrets.repository-password }}
+          username: ${{ inputs.registry-username }}
+          password: ${{ secrets.registry-password }}
 
       - name: Push
         if: ${{ inputs.publish }}


### PR DESCRIPTION
The two inputs `registry-username` and `registry-password` were being referenced as `repository-username` and `repository-password`.