### PR TITLE
ci: revert to trivy template format

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -140,8 +140,9 @@ jobs:
         with:
           image-ref: ${{ inputs.repository }}/${{ matrix.image }}:${{ inputs.tag }}
           #input: /tmp/image-${{ inputs.image-name }}.tar
-          format: 'sarif'
+          format: 'template'
           exit-code: ${{ steps.exit-code.outputs.exit_code }}
+          template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL
 


### PR DESCRIPTION
Reverts back to template format.

Sarif does not respect severity option for scan.

[#95](https://github.com/aquasecurity/trivy-action/issues/95)