### PR TITLE
feat: add offline-scan option for image scan workflow

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -63,6 +63,12 @@ on:
         type: string
         default: 5m
 
+      # scan java dependencies without use of API requests to scan
+      offline-scan:
+        required: false
+        type: boolean
+        default: false
+
       # Container Registry config
       registry-username:
         required: false
@@ -152,6 +158,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL
           timeout: ${{ inputs.timeout }}
+          offline-scan: ${{ inputs.offline-scan }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -158,7 +158,8 @@ jobs:
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL
           timeout: ${{ inputs.timeout }}
-          offline-scan: ${{ inputs.offline-scan }}
+        env:
+          TRIVY_OFFLINE_SCAN: ${{ inputs.offline-scan }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
Using offline-scan to resolve timeout issues for [image-builder-gradle](https://github.com/liatrio/image-builder-gradle) and [image-jenkins](https://github.com/liatrio/image-jenkins) in regards to the [aquasecurity/issue#190](https://github.com/aquasecurity/trivy-action/issues/190)