### PR TITLE
fix: Update monorepo semantic release to use /v as default delimiter

### DIFF
--- a/.github/workflows/monorepo-semantic-release.yaml
+++ b/.github/workflows/monorepo-semantic-release.yaml
@@ -13,7 +13,7 @@ on:
         type: string
         default: "/**"
       version-delimiter:
-        description: "The delimiter between the module name and semantic version number in the resulting releases. Defaults to '-v'"
+        description: "The delimiter between the module name and semantic version number in the resulting releases. Defaults to '/v'"
         required: false
         type: string
         default: "/v"

--- a/.github/workflows/monorepo-semantic-release.yaml
+++ b/.github/workflows/monorepo-semantic-release.yaml
@@ -16,7 +16,7 @@ on:
         description: "The delimiter between the module name and semantic version number in the resulting releases. Defaults to '-v'"
         required: false
         type: string
-        default: "-v"
+        default: "/v"
 
 jobs:
   setup:


### PR DESCRIPTION
BREAKING CHANGE: changes default value of version delimiter in monorepo-semantic-release workflow to '/v' from '-v